### PR TITLE
Return to top functionality

### DIFF
--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -203,14 +203,6 @@
 		} );
 	} );
 
-	wp.customize( 'eli_back_to_top', function( value ) {
-			value.bind( function( to ) {
-				if ( to ) {
-					$( '.button-to-top' ).css('opacity', 1 );
-				} else {
-					$( '.button-to-top' ).css('opacity', 0 );
-				}
-			} );
-	} );
+	
 
 } )( jQuery );

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -8,9 +8,6 @@
 
 ( function( $ ) {
 
-
-
-
 	wp.customize( 'eli_footer_copyright_text', function( value ) {
 
 		value.bind( function( to ) {
@@ -204,6 +201,16 @@
 		value.bind( function( newval ) {
 			$('.footer').css('color', newval );
 		} );
+	} );
+
+	wp.customize( 'eli_back_to_top', function( value ) {
+			value.bind( function( to ) {
+				if ( to ) {
+					$( '.button-to-top' ).css('opacity', 1 );
+				} else {
+					$( '.button-to-top' ).css('opacity', 0 );
+				}
+			} );
 	} );
 
 } )( jQuery );

--- a/assets/js/eli-floatingbuttons.js
+++ b/assets/js/eli-floatingbuttons.js
@@ -15,7 +15,6 @@ jQuery(document).ready(function($){
             } else {
                 $('.button-to-top').addClass('button-to-top-visible');
               }
-          
             },250);
       });
 

--- a/assets/js/eli-floatingbuttons.js
+++ b/assets/js/eli-floatingbuttons.js
@@ -1,0 +1,27 @@
+
+jQuery(document).ready(function($){
+    var offset = 100;
+    var speed = 250;
+    var duration = 500;
+    var scrollTimer;
+
+    //check if scrolling stopped for more than 250 milliseconds, and if scrolling is more than 100px from top
+
+	   $(window).on('scroll', function(){
+        clearTimeout(scrollTimer);
+        scrollTimer = setTimeout(function() {
+            if ($(this).scrollTop() < offset) {
+              $('.button-to-top').removeClass('button-to-top-visible');
+            } else {
+                $('.button-to-top').addClass('button-to-top-visible');
+              }
+          
+            },250);
+      });
+
+	    $(".button-to-top").on("click", function () {
+		    $('html, body').animate({scrollTop:0}, speed);
+		    return false;
+        });
+ 
+});

--- a/footer.php
+++ b/footer.php
@@ -14,7 +14,6 @@
 	    //		$back_to_top = apply_filters('eli_back_to_top', __('<i class="fa fa-chevron-up"></i> Back to Top', 'eli') );					
 		if( !empty(get_theme_mod( 'eli_back_to_top' )) )
 			echo '<a href="#" class="button-to-top"><i class="fa fa-chevron-up"></i></a>';
-
 	?>
 </div>
 

--- a/footer.php
+++ b/footer.php
@@ -6,6 +6,20 @@
  */
 ?>
 
+<div>
+	<?php
+		
+		//$back_to_top = get_theme_mod( 'eli_back_to_top' ) ;
+		//if( !empty($back_to_top) )
+	    //		$back_to_top = apply_filters('eli_back_to_top', __('<i class="fa fa-chevron-up"></i> Back to Top', 'eli') );					
+		if( !empty(get_theme_mod( 'eli_back_to_top' )) )
+			echo '<a href="#" class="button-to-top"><i class="fa fa-chevron-up"></i></a>';
+
+	?>
+</div>
+
+
+
 <?php
 	do_action( 'eli_before_body_tag' );
 

--- a/functions.php
+++ b/functions.php
@@ -80,11 +80,15 @@ function eli_scripts() {
 	// Custom JQuery file
 	// wp_enqueue_script( 'eli_jquery', get_theme_file_uri( '/assets/js/eli-jquery.js'), array( 'jquery' ) );
 
+	//Script file for floating buttons
+	wp_enqueue_script( 'eli_floatingbuttons', get_theme_file_uri( '/assets/js/eli-floatingbuttons.js'), array( 'jquery' ) );
+
 	wp_enqueue_style( 'font-awesome', get_theme_file_uri( '/includes/font-awesome/css/font-awesome.min.css' ) );
 
 	do_action("eli_enqueue_script_extender");
 
 }
+
 add_action( 'wp_enqueue_scripts', 'eli_scripts' );
 
 /**

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -497,12 +497,11 @@ function eli_customizer_register( $wp_customize ) {
          )
     );
 
-    $wp_customize->add_setting( 'eli_back_to_top', //No need to use a SERIALIZED name, as `theme_mod` settings already live under one db record
+    $wp_customize->add_setting( 'eli_back_to_top', 
          array(
-            'default'    =>  false, //Default setting/value to save
-            'type'       => 'theme_mod', //Is this an 'option' or a 'theme_mod'?
-            'capability' => 'edit_theme_options', //Optional. Special permissions for accessing this setting.
-            'transport'  => 'postMessage' //What triggers a refresh of the setting? 'refresh' or 'postMessage' (instant)?
+            'default'    =>  true,
+            'type'       => 'theme_mod',
+            'transport'  => 'refresh' //Using refresh to ensure HTML element is loaded if the setting was false. 
          )
       );
 
@@ -515,6 +514,7 @@ function eli_customizer_register( $wp_customize ) {
             'priority' => '130'
         )
     );
+    
 
 
 }

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -483,6 +483,39 @@ function eli_customizer_register( $wp_customize ) {
         ) )
     );
 
+     /**
+     *
+     * START OF FLOATING BUTTONS
+     *
+     */
+    $wp_customize->add_section( 'eli_floating_buttons',
+         array(
+            'title'       => __( 'Floating Buttons', 'eli' ), //Visible title of section
+            'priority'    => 31, //Determines what order this appears in
+            'capability'  => 'edit_theme_options', //Capability needed to tweak
+            'description' => __( 'Show floating buttons.' , 'eli' ), //Descriptive tooltip
+         )
+    );
+
+    $wp_customize->add_setting( 'eli_back_to_top', //No need to use a SERIALIZED name, as `theme_mod` settings already live under one db record
+         array(
+            'default'    =>  false, //Default setting/value to save
+            'type'       => 'theme_mod', //Is this an 'option' or a 'theme_mod'?
+            'capability' => 'edit_theme_options', //Optional. Special permissions for accessing this setting.
+            'transport'  => 'postMessage' //What triggers a refresh of the setting? 'refresh' or 'postMessage' (instant)?
+         )
+      );
+
+    $wp_customize->add_control( 'eli_back_to_top', 
+        array(
+            'type' => 'checkbox',
+            'label' => 'Show Back to Top Link', 
+            'section' => 'eli_floating_buttons',
+            'settings' => 'eli_back_to_top',
+            'priority' => '130'
+        )
+    );
+
 
 }
 add_action( 'customize_register', 'eli_customizer_register' );

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -122,6 +122,15 @@ function eli_customizer_register( $wp_customize ) {
          )
     );
 
+    //Back to top floating button
+    $wp_customize->add_setting( 'eli_back_to_top', 
+        array(
+        'default'    =>  true,
+        'type'       => 'theme_mod',
+        'transport'  => 'refresh' //Using refresh to ensure HTML element is loaded if the setting was false. 
+        )
+    );
+
     $wp_customize->add_control( new WP_Customize_Control( //Instantiate the color control class
          $wp_customize, //Pass the $wp_customize object (required)
          'eli_show_social_media', //Set a unique ID for the control
@@ -132,6 +141,15 @@ function eli_customizer_register( $wp_customize ) {
             'section'    => 'eli_footer',
          )
     ) );
+
+    $wp_customize->add_control( 'eli_back_to_top', 
+        array(
+            'type' => 'checkbox',
+            'label' => 'Show Back to Top Link', 
+            'section' => 'eli_footer',
+            'settings' => 'eli_back_to_top'
+        )
+   );
 
 	// Control for text itself.
    	$wp_customize->add_control( new WP_Customize_Control ( //Instantiate the color control class
@@ -482,39 +500,7 @@ function eli_customizer_register( $wp_customize ) {
             'settings'   => 'eli_footer_color',
         ) )
     );
-
-     /**
-     *
-     * START OF FLOATING BUTTONS
-     *
-     */
-    $wp_customize->add_section( 'eli_floating_buttons',
-         array(
-            'title'       => __( 'Floating Buttons', 'eli' ), //Visible title of section
-            'priority'    => 31, //Determines what order this appears in
-            'capability'  => 'edit_theme_options', //Capability needed to tweak
-            'description' => __( 'Show floating buttons.' , 'eli' ), //Descriptive tooltip
-         )
-    );
-
-    $wp_customize->add_setting( 'eli_back_to_top', 
-         array(
-            'default'    =>  true,
-            'type'       => 'theme_mod',
-            'transport'  => 'refresh' //Using refresh to ensure HTML element is loaded if the setting was false. 
-         )
-      );
-
-    $wp_customize->add_control( 'eli_back_to_top', 
-        array(
-            'type' => 'checkbox',
-            'label' => 'Show Back to Top Link', 
-            'section' => 'eli_floating_buttons',
-            'settings' => 'eli_back_to_top',
-            'priority' => '130'
-        )
-    );
-    
+   
 
 
 }

--- a/style.css
+++ b/style.css
@@ -124,18 +124,20 @@ a:hover{
 
 /** Back to top button **/
 .button-to-top {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: fixed;
+  background-color: rgba(255,255,255,0.5);
   bottom: 20px;
   right: 20px;
   z-index: 100;
   width: 60px;
   height: 60px;
+  padding-bottom: 10px;
   border: 0;
-  border-radius: 2px;
-  box-shadow: none;
-  line-height: 20px;
-  font-size: 26px;
-  text-align: center;
+  border-radius: 50%;
+  font-size: 40px;
   cursor: pointer;
   pointer-events: none;
   opacity: 0;
@@ -145,6 +147,10 @@ a:hover{
 .button-to-top-visible {
   pointer-events: auto;
   opacity: 1;
+}
+
+.button-to-top i {
+  box-shadow: 
 }
 
 /* Sticky Header Navigation Top */

--- a/style.css
+++ b/style.css
@@ -133,12 +133,8 @@ a:hover{
   border: 0;
   border-radius: 2px;
   box-shadow: none;
- /* background: #145474;
- 
- color: #fff; */
- line-height: 20px;
+  line-height: 20px;
   font-size: 26px;
-  
   text-align: center;
   cursor: pointer;
   pointer-events: none;

--- a/style.css
+++ b/style.css
@@ -121,6 +121,36 @@ a:hover{
     color:#333;
     text-decoration:none; 
 }
+
+/** Back to top button **/
+.button-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 100;
+  width: 60px;
+  height: 60px;
+  border: 0;
+  border-radius: 2px;
+  box-shadow: none;
+ /* background: #145474;
+ 
+ color: #fff; */
+ line-height: 20px;
+  font-size: 26px;
+  
+  text-align: center;
+  cursor: pointer;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .18s ease;
+}
+
+.button-to-top-visible {
+  pointer-events: auto;
+  opacity: 1;
+}
+
 /* Sticky Header Navigation Top */
 .sticky-top{ background:rgba( 255, 255, 255, 0.7 ); }
 


### PR DESCRIPTION
1. Created new section in customizer for floating buttons. We can add more floating buttons in future if needed.
2. Floating back-to-top button will appear if users started to scroll down, and will dissapear when user is at the top of the page

The customizer setting refreshes the preview page to force reload the HTML element for the floating button (and not `transport => postMessage`. This is to overcome the issue when the setting was deactivated before, and the user now wants to reactivate the floating back-to-button. If the setting was set to false, then the HTML was not generated when the page loaded.
